### PR TITLE
Fix #3: slow matrix addition due to type instability

### DIFF
--- a/src/LengthFreeStaticMatrices.jl
+++ b/src/LengthFreeStaticMatrices.jl
@@ -22,6 +22,8 @@ function nest_tuple(::Type{T}, t::Tuple, ::Size{S}) where {T,S}
         (M,N) = S
         return ntuple(i -> NTuple{M,T}(t[(M * (i-1)) .+ (1:M)]), Val{N}())
     end
+    # This generic implementation is type unstable
+    # Probably best to implement it as a generated function
     return ntuple(last(S)) do i
         SS = S[1:end-1]
         index_range = S[end-1]*(i-1) .+ (1:prod(SS))

--- a/src/LengthFreeStaticMatrices.jl
+++ b/src/LengthFreeStaticMatrices.jl
@@ -15,7 +15,13 @@ function nest_tuple(::Type{T}, t::Tuple, ::Size{S}) where {T,S}
     @assert length(t) === prod(S) string(
         "Input tuple must have length ", prod(S), " (got length ", length(t), ")."
     )
-    isone(length(S)) && return NTuple{only(S),T}(t)
+    # Specialized implementation for matrices should solve type inference problem
+    if length(S) === 1
+        return NTuple{only(S),T}(t)
+    elseif length(S) === 2
+        (M,N) = S
+        return ntuple(i -> NTuple{M,T}(t[(M * (i-1)) .+ (1:M)]), Val{N}())
+    end
     return ntuple(last(S)) do i
         SS = S[1:end-1]
         index_range = S[end-1]*(i-1) .+ (1:prod(SS))

--- a/src/LengthFreeStaticMatrices.jl
+++ b/src/LengthFreeStaticMatrices.jl
@@ -12,7 +12,7 @@ import Base: @propagate_inbounds
 Converts a flat tuple `t` into nested tuples `NTuple{S[1],NTuple{S[2],...}}` to arbitrary depth.
 """
 function nest_tuple(::Type{T}, t::Tuple, ::Size{S}) where {T,S}
-    @assert length(t) ===  prod(S) string(
+    @assert length(t) === prod(S) string(
         "Input tuple must have length ", prod(S), " (got length ", length(t), ")."
     )
     isone(length(S)) && return NTuple{only(S),T}(t)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -12,8 +12,12 @@ Aqua.test_all(LengthFreeStaticMatrices)
         t = NTuple{6}(1:6)
         @test nest_tuple(Float64, t, Size(6)) === NTuple{6,Float64}(1:6)
         @test nest_tuple(Float64, t, Size(3,2)) === ((1.0, 2.0, 3.0), (4.0, 5.0, 6.0))
+        @test nest_tuple(Float64, t, Size(2,3,1)) === tuple(
+            ((1.0, 2.0), (3.0, 4.0), (5.0, 6.0))
+        )
         @test nest_tuple(t, Size(6)) === NTuple{6}(1:6)
         @test nest_tuple(t, Size(3,2)) === ((1, 2, 3), (4, 5, 6))
+        @test nest_tuple(t, Size(2,3,1)) === tuple(((1,2), (3,4), (5,6)))
     end
     @testset "Constructors and conversion" begin
         @test LSMatrix{3,2}(t) === x


### PR DESCRIPTION
It seems that the generic implementation of `LengthFreeStaticMatrices.nest_tuple`, which could nest tuples to arbitrary depth, could not automatically infer the type of the result. This is the cause of #3, and this PR should fix it.

The elegant solution to this problem is likely a generated function, but for now, this seems to significantly improve performance, and specialization is only needed for the 2D case since we're not dealing with arbitrary arrays.